### PR TITLE
Enable updateTextInput for shiny inputs.

### DIFF
--- a/inst/www/dist.js
+++ b/inst/www/dist.js
@@ -100,6 +100,16 @@
 	      policy: 'debounce',
 	      delay: 500
 	    };
+	  },
+
+	  receiveMessage: function(el, data) {
+	    if (data.hasOwnProperty('value'))
+	      this.setValue(el, data.value);
+
+	    if (data.hasOwnProperty('label'))
+	      $(el).closest(".ui").dropdown('set selected', data.label)
+
+	    $(el).trigger('change');
 	  }
 	});
 

--- a/inst/www/dist.js
+++ b/inst/www/dist.js
@@ -103,11 +103,18 @@
 	  },
 
 	  receiveMessage: function(el, data) {
+	    console.log(JSON.stringify(data))
 	    if (data.hasOwnProperty('value'))
 	      this.setValue(el, data.value);
 
-	    if (data.hasOwnProperty('label'))
-	      $(el).closest(".ui").dropdown('set selected', data.label)
+	    if (data.hasOwnProperty('label')) {
+	      var input = $(el).closest(".ui");
+	      if (data.label === "") {
+	        input.dropdown('remove selected')
+	      } else {
+	        input.dropdown('set selected', data.label)
+	      }
+	    }
 
 	    $(el).trigger('change');
 	  }

--- a/inst/www/shiny-binding.js
+++ b/inst/www/shiny-binding.js
@@ -54,6 +54,16 @@ $.extend(customShinyInputBinding, {
       policy: 'debounce',
       delay: 500
     };
+  },
+
+  receiveMessage: function(el, data) {
+    if (data.hasOwnProperty('value'))
+      this.setValue(el, data.value);
+
+    if (data.hasOwnProperty('label'))
+      $(el).closest(".ui").dropdown('set selected', data.label)
+
+    $(el).trigger('change');
   }
 });
 

--- a/inst/www/shiny-binding.js
+++ b/inst/www/shiny-binding.js
@@ -57,11 +57,18 @@ $.extend(customShinyInputBinding, {
   },
 
   receiveMessage: function(el, data) {
+    console.log(JSON.stringify(data))
     if (data.hasOwnProperty('value'))
       this.setValue(el, data.value);
 
-    if (data.hasOwnProperty('label'))
-      $(el).closest(".ui").dropdown('set selected', data.label)
+    if (data.hasOwnProperty('label')) {
+      var input = $(el).closest(".ui");
+      if (data.label === "") {
+        input.dropdown('remove selected')
+      } else {
+        input.dropdown('set selected', data.label)
+      }
+    }
 
     $(el).trigger('change');
   }


### PR DESCRIPTION
This change allows shiny apps to call update*Input methods to update the value of an input.
It mostly based on the code from https://github.com/rstudio/shiny/blob/9613c58bf8120bcfdab35801b17167418b5464ac/srcjs/input_binding_text.js#L26